### PR TITLE
Add candidate upload backend and frontend flows

### DIFF
--- a/jobfit/api/db.py
+++ b/jobfit/api/db.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./jobfit.db")
+
+connect_args: dict[str, object] = {}
+if DATABASE_URL.startswith("sqlite"):
+    connect_args = {"check_same_thread": False}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+
+
+class Base(DeclarativeBase):
+    """Base class for SQLAlchemy models."""
+
+
+SessionGenerator = Generator[Session, None, None]
+
+
+def get_session() -> SessionGenerator:
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def init_db() -> None:
+    """Ensure all tables are created."""
+    # Import models within the function to avoid circular imports.
+    import models  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)

--- a/jobfit/api/main.py
+++ b/jobfit/api/main.py
@@ -1,9 +1,13 @@
+from pathlib import Path
+
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from routers.core import router
+from db import init_db
+from routers.core import router as core_router
+from routers.upload import router as upload_router
 
 app = FastAPI(title="JobFit API")
 
@@ -13,6 +17,15 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+STORAGE_DIR = Path(__file__).resolve().parent / "storage"
+
+
+@app.on_event("startup")
+def ensure_storage_and_tables() -> None:
+    STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+    init_db()
 
 
 @app.exception_handler(RequestValidationError)
@@ -26,4 +39,5 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     )
 
 
-app.include_router(router)
+app.include_router(core_router)
+app.include_router(upload_router, prefix="/upload")

--- a/jobfit/api/models.py
+++ b/jobfit/api/models.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db import Base, engine
+
+try:  # pragma: no cover - JSONB import might fail outside Postgres
+    backend = engine.url.get_backend_name()
+except AttributeError:  # pragma: no cover
+    backend = ""
+
+if backend == "postgresql":
+    JSONType = JSONB
+else:
+    from sqlalchemy import JSON as JSONType  # type: ignore
+
+
+class Source(Base):
+    __tablename__ = "sources"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    candidate_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    type: Mapped[str] = mapped_column(String(32), nullable=False)
+    filename: Mapped[str] = mapped_column(String(512), nullable=False)
+    path: Mapped[Optional[str]] = mapped_column(String(1024))
+    mimetype: Mapped[Optional[str]] = mapped_column(String(255))
+    bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    checksum: Mapped[str] = mapped_column(String(128), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    chunks: Mapped[list["Chunk"]] = relationship(
+        back_populates="source", cascade="all, delete-orphan"
+    )
+
+
+class Chunk(Base):
+    __tablename__ = "chunks"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    source_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("sources.id", ondelete="CASCADE"), nullable=False
+    )
+    kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    meta: Mapped[Optional[dict[str, Any]]] = mapped_column(JSONType)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    source: Mapped[Source] = relationship(back_populates="chunks")

--- a/jobfit/api/requirements.txt
+++ b/jobfit/api/requirements.txt
@@ -3,4 +3,6 @@ uvicorn[standard]==0.29.0
 pydantic==2.6.4
 SQLAlchemy==2.0.27
 psycopg[binary]==3.1.18
+pypdf==4.2.0
+python-docx==1.1.0
 pytest==8.1.1

--- a/jobfit/api/routers/upload.py
+++ b/jobfit/api/routers/upload.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import hashlib
+import unicodedata
+from pathlib import Path
+from typing import Annotated
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from db import get_session
+from models import Chunk, Source
+from services.parsing import read_docx_text, read_pdf_text, split_cv, split_transcript
+
+MAX_UPLOAD_BYTES = 8 * 1024 * 1024
+STORAGE_DIR = Path(__file__).resolve().parent.parent / "storage"
+
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+ALLOWED_CV_MIME_TYPES = {"application/pdf", DOCX_MIME}
+ALLOWED_TRANSCRIPT_MIME_TYPES = {"application/pdf", DOCX_MIME, "text/plain"}
+
+router = APIRouter()
+
+SessionDep = Annotated[Session, Depends(get_session)]
+
+
+class CVSection(BaseModel):
+    name: str
+    bullets: list[str] = Field(default_factory=list)
+
+
+class CVPreview(BaseModel):
+    sections: list[CVSection] = Field(default_factory=list)
+
+
+class CVUploadResponse(BaseModel):
+    source_id: str
+    cv_preview: CVPreview
+    saved: bool
+
+
+class SourceInfo(BaseModel):
+    id: str
+    filename: str
+
+
+class ContextUploadResponse(BaseModel):
+    sources: list[SourceInfo]
+    paragraph_counts: list[int]
+    saved: bool
+
+
+from datetime import datetime
+
+
+class SourceSummary(BaseModel):
+    id: str
+    filename: str
+    type: str
+    mimetype: str | None = None
+    bytes: int
+    created_at: datetime
+    chunk_count: int
+
+
+class SourceListResponse(BaseModel):
+    sources: list[SourceSummary]
+
+
+def sanitize_filename(filename: str | None) -> str:
+    if not filename:
+        return "upload"
+    name = Path(filename).name
+    normalized = unicodedata.normalize("NFKD", name)
+    ascii_name = normalized.encode("ascii", "ignore").decode() or name
+    safe = "".join(char for char in ascii_name if char.isalnum() or char in {".", "_", "-"})
+    safe = safe.strip(".")
+    return safe or "upload"
+
+
+async def save_upload(file: UploadFile, target_name: str) -> tuple[Path, bytes, str]:
+    content = await file.read()
+    size = len(content)
+    if size > MAX_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail="File too large (max 8 MB)",
+        )
+    safe_name = sanitize_filename(file.filename)
+    filename = f"{target_name}_{safe_name}"
+    STORAGE_DIR.mkdir(parents=True, exist_ok=True)
+    destination = STORAGE_DIR / filename
+    with open(destination, "wb") as output:
+        output.write(content)
+    return destination, content, safe_name
+
+
+def checksum_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def extract_text(path: Path, mimetype: str, raw_bytes: bytes) -> str:
+    if mimetype == "application/pdf":
+        return read_pdf_text(path)
+    if mimetype == DOCX_MIME:
+        return read_docx_text(path)
+    if mimetype == "text/plain":
+        return raw_bytes.decode("utf-8", errors="ignore")
+    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported file type")
+
+
+@router.post("/cv", response_model=CVUploadResponse)
+async def upload_cv(
+    cv_file: Annotated[UploadFile, File(...)],
+    candidate_id: Annotated[str, Form("demo")] = "demo",
+    session: SessionDep,
+):
+    if cv_file.content_type not in ALLOWED_CV_MIME_TYPES:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported CV file type")
+
+    source_id = str(uuid4())
+    storage_path, raw_bytes, safe_name = await save_upload(cv_file, source_id)
+    checksum = checksum_bytes(raw_bytes)
+    candidate = candidate_id or "demo"
+
+    try:
+        text = extract_text(storage_path, cv_file.content_type, raw_bytes)
+    except Exception as exc:  # pragma: no cover - unexpected read issues
+        if storage_path.exists():
+            storage_path.unlink(missing_ok=True)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to read CV file") from exc
+
+    preview_dict = split_cv(text)
+    preview = CVPreview.model_validate(preview_dict)
+
+    source = Source(
+        id=source_id,
+        candidate_id=candidate,
+        type="cv",
+        filename=safe_name,
+        path=str(storage_path),
+        mimetype=cv_file.content_type,
+        bytes=len(raw_bytes),
+        checksum=checksum,
+    )
+    session.add(source)
+
+    for section_index, section in enumerate(preview.sections):
+        section_chunk = Chunk(
+            id=str(uuid4()),
+            source_id=source_id,
+            kind="section",
+            text=section.name,
+            meta={"section_name": section.name, "order": section_index},
+        )
+        session.add(section_chunk)
+        for bullet_index, bullet in enumerate(section.bullets):
+            bullet_chunk = Chunk(
+                id=str(uuid4()),
+                source_id=source_id,
+                kind="bullet",
+                text=bullet,
+                meta={"section_name": section.name, "order": bullet_index},
+            )
+            session.add(bullet_chunk)
+
+    session.commit()
+
+    return CVUploadResponse(source_id=source_id, cv_preview=preview, saved=True)
+
+
+@router.post("/context", response_model=ContextUploadResponse)
+async def upload_context(
+    transcripts: Annotated[list[UploadFile] | None, File(default=None)] = None,
+    notes: Annotated[str | None, Form(default=None)] = None,
+    candidate_id: Annotated[str, Form("demo")] = "demo",
+    session: SessionDep,
+):
+    files = transcripts or []
+    text_note = (notes or "").strip()
+    if not files and not text_note:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Provide transcripts or notes")
+
+    candidate = candidate_id or "demo"
+    saved_sources: list[SourceInfo] = []
+    paragraph_counts: list[int] = []
+
+    for upload in files:
+        if upload.content_type not in ALLOWED_TRANSCRIPT_MIME_TYPES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unsupported transcript file type: {upload.content_type}",
+            )
+        source_id = str(uuid4())
+        storage_path, raw_bytes, safe_name = await save_upload(upload, source_id)
+        checksum = checksum_bytes(raw_bytes)
+        try:
+            text = extract_text(storage_path, upload.content_type or "", raw_bytes)
+        except Exception as exc:  # pragma: no cover - unexpected read issues
+            if storage_path.exists():
+                storage_path.unlink(missing_ok=True)
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to read transcript") from exc
+
+        paragraphs = split_transcript(text)
+
+        source = Source(
+            id=source_id,
+            candidate_id=candidate,
+            type="transcript",
+            filename=safe_name,
+            path=str(storage_path),
+            mimetype=upload.content_type,
+            bytes=len(raw_bytes),
+            checksum=checksum,
+        )
+        session.add(source)
+        for index, paragraph in enumerate(paragraphs):
+            chunk = Chunk(
+                id=str(uuid4()),
+                source_id=source_id,
+                kind="paragraph",
+                text=paragraph,
+                meta={"order": index},
+            )
+            session.add(chunk)
+
+        saved_sources.append(SourceInfo(id=source_id, filename=safe_name))
+        paragraph_counts.append(len(paragraphs))
+
+    if text_note:
+        note_bytes = text_note.encode("utf-8")
+        source_id = str(uuid4())
+        checksum = checksum_bytes(note_bytes)
+        source = Source(
+            id=source_id,
+            candidate_id=candidate,
+            type="transcript",
+            filename="notes.txt",
+            path=None,
+            mimetype="text/plain",
+            bytes=len(note_bytes),
+            checksum=checksum,
+        )
+        session.add(source)
+        note_paragraphs = split_transcript(text_note)
+        for index, paragraph in enumerate(note_paragraphs):
+            chunk = Chunk(
+                id=str(uuid4()),
+                source_id=source_id,
+                kind="paragraph",
+                text=paragraph,
+                meta={"order": index},
+            )
+            session.add(chunk)
+        saved_sources.append(SourceInfo(id=source_id, filename="notes.txt"))
+        paragraph_counts.append(len(note_paragraphs))
+
+    session.commit()
+
+    return ContextUploadResponse(sources=saved_sources, paragraph_counts=paragraph_counts, saved=True)
+
+
+@router.get("/sources", response_model=SourceListResponse)
+async def list_sources(
+    candidate_id: str = "demo",
+    session: SessionDep,
+):
+    statement = (
+        select(Source, func.count(Chunk.id))
+        .join(Chunk, Chunk.source_id == Source.id, isouter=True)
+        .where(Source.candidate_id == candidate_id)
+        .group_by(Source.id)
+        .order_by(Source.created_at.desc())
+        .limit(20)
+    )
+    results = session.execute(statement).all()
+    summaries = [
+        SourceSummary(
+            id=source.id,
+            filename=source.filename,
+            type=source.type,
+            mimetype=source.mimetype,
+            bytes=source.bytes,
+            created_at=source.created_at,
+            chunk_count=int(count or 0),
+        )
+        for source, count in results
+    ]
+    return SourceListResponse(sources=summaries)

--- a/jobfit/api/services/parsing.py
+++ b/jobfit/api/services/parsing.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from docx import Document
+from pypdf import PdfReader
+
+
+def read_pdf_text(file_path: str | Path) -> str:
+    reader = PdfReader(str(file_path))
+    parts: list[str] = []
+    for page in reader.pages:
+        text = page.extract_text() or ""
+        parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def read_docx_text(file_path: str | Path) -> str:
+    document = Document(str(file_path))
+    paragraphs = [paragraph.text for paragraph in document.paragraphs]
+    return "\n".join(paragraphs).strip()
+
+
+SECTION_HEADERS = {"summary", "skills", "experience", "education", "projects"}
+BULLET_PATTERN = re.compile(r"^[\-\*•]\s*(.+)")
+
+
+def split_cv(text: str) -> dict[str, list[dict[str, list[str]]]]:
+    sections: list[dict[str, list[str]]] = []
+    current_section: dict[str, list[str]] | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        heading = line.rstrip(":").strip()
+        if heading.lower() in SECTION_HEADERS:
+            if current_section:
+                sections.append(current_section)
+            current_section = {"name": heading, "bullets": []}
+            continue
+
+        bullet_match = BULLET_PATTERN.match(line)
+        if bullet_match:
+            bullet_text = bullet_match.group(1).strip()
+            if not current_section:
+                current_section = {"name": "Summary", "bullets": []}
+            current_section["bullets"].append(bullet_text)
+            continue
+
+        if not current_section:
+            current_section = {"name": "Summary", "bullets": []}
+        current_section["bullets"].append(line)
+
+    if current_section:
+        sections.append(current_section)
+
+    if not sections:
+        paragraphs = [paragraph.strip() for paragraph in re.split(r"\n\s*\n", text) if paragraph.strip()]
+        if paragraphs:
+            sections = [{"name": "Summary", "bullets": paragraphs}]
+
+    return {"sections": sections}
+
+
+def split_transcript(text: str) -> list[str]:
+    paragraphs: list[str] = []
+    buffer: list[str] = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if buffer:
+                paragraphs.append(" ".join(buffer))
+                buffer = []
+            continue
+        buffer.append(line)
+
+    if buffer:
+        paragraphs.append(" ".join(buffer))
+
+    return paragraphs

--- a/jobfit/api/tests/test_upload.py
+++ b/jobfit/api/tests/test_upload.py
@@ -1,0 +1,64 @@
+import io
+
+from docx import Document
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+def build_docx(paragraphs: list[str]) -> bytes:
+    buffer = io.BytesIO()
+    document = Document()
+    for text in paragraphs:
+        document.add_paragraph(text)
+    document.save(buffer)
+    buffer.seek(0)
+    return buffer.read()
+
+
+def test_upload_cv_docx_returns_preview():
+    doc_bytes = build_docx([
+        "Summary",
+        "- Experienced software engineer",
+        "Experience",
+        "- Built APIs",
+    ])
+    files = {
+        "cv_file": (
+            "sample.docx",
+            doc_bytes,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+    }
+    response = client.post("/upload/cv", files=files, data={"candidate_id": "demo"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["saved"] is True
+    assert body["cv_preview"]["sections"]
+
+
+def test_upload_transcript_text_file():
+    files = [
+        (
+            "transcripts",
+            (
+                "notes.txt",
+                b"Paragraph one.\n\nParagraph two.",
+                "text/plain",
+            ),
+        )
+    ]
+    response = client.post("/upload/context", files=files, data={"candidate_id": "demo"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["saved"] is True
+    assert body["paragraph_counts"]
+    assert body["paragraph_counts"][0] > 0
+
+
+def test_upload_rejects_invalid_mimetype():
+    files = {"cv_file": ("image.png", b"fake", "image/png")}
+    response = client.post("/upload/cv", files=files)
+    assert response.status_code == 400

--- a/jobfit/docker-compose.yml
+++ b/jobfit/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - "8000:8000"
     volumes:
       - ./api:/app
+      - ./api/storage:/app/storage
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 
   web:

--- a/jobfit/web/src/app/page.tsx
+++ b/jobfit/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { apiFetch } from "../lib/api";
 
@@ -38,6 +39,12 @@ export default function HomePage() {
       <div className="rounded-lg border border-slate-700 bg-slate-900 px-4 py-3 text-base">
         {status}
       </div>
+      <Link
+        href="/upload"
+        className="text-sm font-medium text-indigo-400 hover:text-indigo-300"
+      >
+        Upload candidate context
+      </Link>
     </main>
   );
 }

--- a/jobfit/web/src/app/upload/page.tsx
+++ b/jobfit/web/src/app/upload/page.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import type { FormEvent } from "react";
+import { useState } from "react";
+
+import { postForm } from "../../lib/api";
+
+type CVSection = {
+  name: string;
+  bullets: string[];
+};
+
+type CVUploadResponse = {
+  source_id: string;
+  cv_preview: { sections: CVSection[] };
+  saved: boolean;
+};
+
+type ContextSource = {
+  id: string;
+  filename: string;
+};
+
+type ContextUploadResponse = {
+  sources: ContextSource[];
+  paragraph_counts: number[];
+  saved: boolean;
+};
+
+const docxMime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+export default function UploadPage() {
+  const [candidateId, setCandidateId] = useState("demo");
+  const [notes, setNotes] = useState("");
+  const [cvError, setCvError] = useState<string | null>(null);
+  const [contextError, setContextError] = useState<string | null>(null);
+  const [cvUploading, setCvUploading] = useState(false);
+  const [contextUploading, setContextUploading] = useState(false);
+  const [cvResult, setCvResult] = useState<CVUploadResponse | null>(null);
+  const [contextResult, setContextResult] = useState<ContextUploadResponse | null>(null);
+
+  const normalizedCandidateId = candidateId.trim() || "demo";
+
+  const handleCvSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setCvError(null);
+    setCvUploading(true);
+
+    const form = event.currentTarget;
+    const fileInput = form.elements.namedItem("cv_file") as HTMLInputElement | null;
+    const files = fileInput?.files ?? null;
+
+    if (!files || files.length === 0) {
+      setCvUploading(false);
+      setCvError("Select a CV file to upload.");
+      return;
+    }
+
+    const file = files[0];
+    if (![
+      "application/pdf",
+      docxMime,
+    ].includes(file.type)) {
+      setCvUploading(false);
+      setCvError("Please upload a PDF or DOCX file.");
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("candidate_id", normalizedCandidateId);
+    formData.append("cv_file", file);
+
+    try {
+      const response = await postForm<CVUploadResponse>("/upload/cv", formData);
+      setCvResult(response);
+      setCvError(null);
+      form.reset();
+    } catch (error) {
+      setCvResult(null);
+      setCvError(error instanceof Error ? error.message : "Upload failed");
+    } finally {
+      setCvUploading(false);
+    }
+  };
+
+  const handleContextSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setContextError(null);
+    setContextUploading(true);
+
+    const form = event.currentTarget;
+    const transcriptInput = form.elements.namedItem("transcripts") as HTMLInputElement | null;
+    const transcriptFiles = transcriptInput?.files ? Array.from(transcriptInput.files) : [];
+    const trimmedNotes = notes.trim();
+
+    if (transcriptFiles.length === 0 && trimmedNotes.length === 0) {
+      setContextError("Add files or notes before uploading.");
+      setContextUploading(false);
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append("candidate_id", normalizedCandidateId);
+
+    transcriptFiles.forEach((file) => {
+      formData.append("transcripts", file);
+    });
+
+    if (trimmedNotes) {
+      formData.append("notes", trimmedNotes);
+    }
+
+    try {
+      const response = await postForm<ContextUploadResponse>("/upload/context", formData);
+      setContextResult(response);
+      setContextError(null);
+      form.reset();
+      setNotes("");
+    } catch (error) {
+      setContextResult(null);
+      setContextError(error instanceof Error ? error.message : "Upload failed");
+    } finally {
+      setContextUploading(false);
+    }
+  };
+
+  const contextRows = contextResult
+    ? contextResult.sources.map((source, index) => ({
+        ...source,
+        paragraphCount: contextResult.paragraph_counts[index] ?? 0,
+      }))
+    : [];
+
+  return (
+    <main className="mx-auto flex max-w-5xl flex-col gap-8 p-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Upload candidate context</h1>
+        <p className="text-sm text-slate-400">Uploads stay on this machine.</p>
+      </header>
+
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:gap-6">
+        <label className="flex w-full flex-col gap-2 md:max-w-xs">
+          <span className="text-sm font-medium text-slate-300">Candidate ID</span>
+          <input
+            type="text"
+            value={candidateId}
+            onChange={(event) => setCandidateId(event.target.value)}
+            className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            placeholder="demo"
+          />
+        </label>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-6">
+          <h2 className="text-xl font-semibold">CV</h2>
+          <p className="mt-1 text-sm text-slate-400">Supported types: PDF, DOCX.</p>
+          <form onSubmit={handleCvSubmit} className="mt-4 space-y-4">
+            <input
+              type="file"
+              name="cv_file"
+              accept=".pdf,.docx"
+              className="block w-full text-sm text-slate-200 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-600 file:px-4 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-indigo-500"
+            />
+            {cvError && <p className="text-sm text-red-400">{cvError}</p>}
+            <button
+              type="submit"
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-slate-700"
+              disabled={cvUploading}
+            >
+              {cvUploading ? "Uploading..." : "Upload CV"}
+            </button>
+          </form>
+        </section>
+
+        <section className="rounded-lg border border-slate-800 bg-slate-900/70 p-6">
+          <h2 className="text-xl font-semibold">Context</h2>
+          <p className="mt-1 text-sm text-slate-400">Upload transcripts or add quick notes.</p>
+          <form onSubmit={handleContextSubmit} className="mt-4 space-y-4">
+            <input
+              type="file"
+              name="transcripts"
+              multiple
+              accept=".pdf,.docx,.txt"
+              className="block w-full text-sm text-slate-200 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-600 file:px-4 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-indigo-500"
+            />
+            <label className="flex flex-col gap-2 text-sm">
+              <span className="text-sm font-medium text-slate-300">Notes</span>
+              <textarea
+                name="notes"
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+                rows={4}
+                className="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                placeholder="Add a quick summary or reminder"
+              />
+            </label>
+            {contextError && <p className="text-sm text-red-400">{contextError}</p>}
+            <button
+              type="submit"
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:bg-slate-700"
+              disabled={contextUploading}
+            >
+              {contextUploading ? "Uploading..." : "Upload context"}
+            </button>
+          </form>
+        </section>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-6">
+          <h3 className="text-lg font-semibold">CV preview</h3>
+          {!cvResult ? (
+            <p className="mt-2 text-sm text-slate-400">Upload a CV to see the parsed sections.</p>
+          ) : cvResult.cv_preview.sections.length === 0 ? (
+            <p className="mt-2 text-sm text-slate-400">No sections detected in this CV.</p>
+          ) : (
+            <ul className="mt-4 space-y-4 text-sm">
+              {cvResult.cv_preview.sections.map((section, sectionIndex) => (
+                <li key={`${section.name}-${sectionIndex}`} className="space-y-2">
+                  <p className="font-medium text-slate-100">{section.name}</p>
+                  <ul className="space-y-1 text-slate-300">
+                    {section.bullets.map((bullet, index) => (
+                      <li key={`${section.name}-${index}`}>• {bullet}</li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="rounded-lg border border-slate-800 bg-slate-900/70 p-6">
+          <h3 className="text-lg font-semibold">Context result</h3>
+          {!contextResult ? (
+            <p className="mt-2 text-sm text-slate-400">Upload transcripts or notes to preview paragraphs.</p>
+          ) : contextRows.length === 0 ? (
+            <p className="mt-2 text-sm text-slate-400">No transcripts processed yet.</p>
+          ) : (
+            <div className="mt-4 overflow-x-auto">
+              <table className="min-w-full text-left text-sm">
+                <thead className="text-slate-300">
+                  <tr>
+                    <th className="px-2 py-1">Filename</th>
+                    <th className="px-2 py-1 text-right">Paragraphs</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {contextRows.map((row) => (
+                    <tr key={row.id} className="border-t border-slate-800 text-slate-200">
+                      <td className="px-2 py-2">{row.filename}</td>
+                      <td className="px-2 py-2 text-right">{row.paragraphCount}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/jobfit/web/src/lib/api.ts
+++ b/jobfit/web/src/lib/api.ts
@@ -29,3 +29,46 @@ export async function apiFetch<T = unknown>(
 
   return (await response.json()) as T;
 }
+
+export async function postForm<T = unknown>(
+  path: string,
+  formData: FormData
+): Promise<T> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? defaultBaseUrl;
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const contentType = response.headers.get("content-type") ?? "";
+    let message = `Request failed with status ${response.status}`;
+
+    if (contentType.includes("application/json")) {
+      try {
+        const body = await response.json();
+        message =
+          (typeof body?.detail === "string" && body.detail) ||
+          (typeof body?.message === "string" && body.message) ||
+          JSON.stringify(body);
+      } catch {
+        // Ignore JSON parsing errors and fall back to default message.
+      }
+    } else {
+      const text = await response.text();
+      if (text) {
+        message = text;
+      }
+    }
+
+    throw new Error(message);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return (await response.json()) as T;
+  }
+
+  const text = await response.text();
+  return text as unknown as T;
+}


### PR DESCRIPTION
## Summary
- add SQLAlchemy session management, storage initialization, and a new upload router for CV and transcript ingestion with chunk persistence
- create PDF/DOCX parsing helpers, database models, storage volume configuration, and automated tests covering the new upload endpoints
- deliver a Next.js upload page with multipart form helpers, previews, and navigation from the home screen

## Testing
- `pip install -r requirements.txt` *(fails: proxy blocks package downloads)*
- `pytest` *(fails: fastapi/docx dependencies unavailable because installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68cbff009fc88333bfd1d87e3028da53