### PR TITLE
Allow configuring API CORS origins via environment variable

### DIFF
--- a/jobfit/README.md
+++ b/jobfit/README.md
@@ -36,6 +36,7 @@ Docker Compose sets the following key environment variables:
 - `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000` for the web container.
 - `DATABASE_URL=postgresql+psycopg://jobfit:jobfit@db:5432/jobfit` for the API container.
 - `POSTGRES_USER=jobfit`, `POSTGRES_PASSWORD=jobfit`, and `POSTGRES_DB=jobfit` for the database container.
+- `JOBFIT_CORS_ORIGINS=http://localhost:3000` for the API container. Provide a comma-separated list when multiple frontend origins need access.
 
 The backend exposes a feature flag in `api/config.py` named `USE_LIVE_OPENAI`. It defaults to `False` and is not used yet. All services currently rely on local mock JSON data.
 

--- a/jobfit/api/main.py
+++ b/jobfit/api/main.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from fastapi import FastAPI, Request
@@ -9,11 +10,24 @@ from db import init_db
 from routers.core import router as core_router
 from routers.upload import router as upload_router
 
+DEFAULT_CORS_ORIGINS = ["http://localhost:3000"]
+
+
+def get_cors_origins() -> list[str]:
+    raw_origins = os.getenv("JOBFIT_CORS_ORIGINS")
+    if not raw_origins:
+        return DEFAULT_CORS_ORIGINS
+
+    parsed_origins = [origin.strip() for origin in raw_origins.split(",")]
+    origins = [origin for origin in parsed_origins if origin]
+    return origins or DEFAULT_CORS_ORIGINS
+
+
 app = FastAPI(title="JobFit API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=get_cors_origins(),
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/jobfit/docker-compose.yml
+++ b/jobfit/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     environment:
       DATABASE_URL: postgresql+psycopg://jobfit:jobfit@db:5432/jobfit
       USE_LIVE_OPENAI: "false"
+      JOBFIT_CORS_ORIGINS: "http://localhost:3000"
     depends_on:
       - db
     ports:


### PR DESCRIPTION
## Summary
- allow the FastAPI app to read allowed CORS origins from the JOBFIT_CORS_ORIGINS environment variable while defaulting to localhost
- set JOBFIT_CORS_ORIGINS in the local docker-compose configuration
- document the new JOBFIT_CORS_ORIGINS setting in the README for future deployments

## Testing
- ⚠️ `pip install -r requirements.txt` *(fails: ProxyError prevents downloading pypdf)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0980ecb88333abedb749851f97bd