### PR TITLE
Fix client API base URL fallback for deployed builds

### DIFF
--- a/jobfit/web/src/lib/api.test.ts
+++ b/jobfit/web/src/lib/api.test.ts
@@ -12,7 +12,11 @@ describe("apiFetch", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    process.env.NEXT_PUBLIC_API_BASE_URL = originalEnv;
+    if (typeof originalEnv === "undefined") {
+      delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_BASE_URL = originalEnv;
+    }
   });
 
   it("calls fetch with the provided path", async () => {
@@ -21,7 +25,7 @@ describe("apiFetch", () => {
       ok: true,
       status: 200,
       json: vi.fn().mockResolvedValue(mockJson),
-      text: vi.fn(),
+      text: vi.fn().mockResolvedValue(JSON.stringify(mockJson)),
     } as unknown as Response;
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
@@ -29,11 +33,15 @@ describe("apiFetch", () => {
 
     const result = await apiFetch("/healthz");
 
-    expect(fetchSpy).toHaveBeenCalledWith("http://test.local/healthz", {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://test.local/healthz",
+      expect.objectContaining({
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+      }),
+    );
     expect(result).toEqual(mockJson);
   });
 
@@ -47,7 +55,46 @@ describe("apiFetch", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse);
 
     await expect(apiFetch("/fail")).rejects.toThrow(
-      "Request failed with status 500: Internal error"
+      "Request to http://test.local/fail failed with status 500: Internal error"
     );
+  });
+
+  it("falls back to the browser origin when no env override is set", async () => {
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    const origin = "https://frontend.example.com";
+    const locationSpy = vi
+      .spyOn(window, "location", "get")
+      .mockReturnValue({
+        origin,
+        hostname: "frontend.example.com",
+      } as Location);
+
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: vi.fn(),
+      text: vi.fn().mockResolvedValue("{\"ok\":true}"),
+    } as unknown as Response;
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(mockResponse);
+
+    await apiFetch("/healthz");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${origin}/healthz`,
+      expect.objectContaining({
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+      }),
+    );
+
+    locationSpy.mockRestore();
+    process.env.NODE_ENV = originalNodeEnv;
   });
 });

--- a/jobfit/web/src/lib/api.ts
+++ b/jobfit/web/src/lib/api.ts
@@ -6,6 +6,30 @@ export type FetchOptions = RequestInit & {
 
 const defaultBaseUrl = "http://localhost:8000";
 
+function isLocalHostname(hostname: string | undefined | null): boolean {
+  if (!hostname) return false;
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+
+function resolveBaseUrl(): string {
+  const envBase = process.env.NEXT_PUBLIC_API_BASE_URL?.trim();
+  if (envBase) {
+    return envBase;
+  }
+
+  if (typeof window !== "undefined") {
+    const { origin, hostname } = window.location ?? {};
+    if (origin && origin !== "null") {
+      const shouldUseOrigin = process.env.NODE_ENV === "production" || !isLocalHostname(hostname);
+      if (shouldUseOrigin) {
+        return origin;
+      }
+    }
+  }
+
+  return defaultBaseUrl;
+}
+
 function joinUrl(base: string, path: string) {
   const b = base.replace(/\/$/, "");
   const p = path.startsWith("/") ? path : `/${path}`;
@@ -26,7 +50,7 @@ export async function apiFetch<T = unknown>(
   path: string,
   options: FetchOptions = {}
 ): Promise<T> {
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? defaultBaseUrl;
+  const baseUrl = resolveBaseUrl();
   const url = joinUrl(baseUrl, path);
 
   const {
@@ -57,7 +81,8 @@ export async function apiFetch<T = unknown>(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`API ${res.status} ${res.statusText} at ${url}. ${text}`);
+    const detail = text.trim() || res.statusText || "Unknown error";
+    throw new Error(`Request to ${url} failed with status ${res.status}: ${detail}`);
   }
 
   if (!parseJson) return undefined as unknown as T;
@@ -72,7 +97,7 @@ export async function postForm<T = unknown>(
   formData: FormData,
   timeoutMs = 60_000
 ): Promise<T> {
-  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? defaultBaseUrl;
+  const baseUrl = resolveBaseUrl();
   const url = joinUrl(baseUrl, path);
 
   const res = await fetchWithTimeout(


### PR DESCRIPTION
## Summary
- resolve the frontend API base URL by preferring NEXT_PUBLIC_API_BASE_URL, using the browser origin in production, and keeping the localhost default for local development
- surface clearer error text when API requests fail and reuse the shared base URL logic for form submissions
- update apiFetch tests to match the new behavior and cover the origin fallback scenario

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7dc33ef883339016f47f50638566