### PR TITLE
Fix CV preview inline bullets and context notes uploads

### DIFF
--- a/jobfit/api/routers/upload.py
+++ b/jobfit/api/routers/upload.py
@@ -175,9 +175,9 @@ async def upload_cv(
 @router.post("/context", response_model=ContextUploadResponse)
 async def upload_context(
     session: SessionDep,
-    transcripts: Annotated[list[UploadFile], File()] | None = None,  # default after '='
-    notes: Annotated[str, Form()] | None = None,                     # default after '='
-    candidate_id: Annotated[str, Form()] = "demo",
+    transcripts: Annotated[list[UploadFile] | None, File()] = File(default=None),
+    notes: Annotated[str | None, Form()] = Form(default=None),
+    candidate_id: Annotated[str, Form()] = Form(default="demo"),
 ):
     files = transcripts or []
     text_note = (notes or "").strip()

--- a/jobfit/api/services/parsing.py
+++ b/jobfit/api/services/parsing.py
@@ -64,6 +64,9 @@ def split_transcript(text: str) -> List[str]:
 BULLET_MARKERS = ("•", "-", "–", "*", "·")
 END_PUNCT = re.compile(r"[.!?…]$")
 
+INLINE_BULLET_CHARS = "".join(ch for ch in BULLET_MARKERS if ch != "-")
+INLINE_BULLET_PATTERN = re.compile(rf"\s*[{re.escape(INLINE_BULLET_CHARS)}]\s*")
+
 
 def _is_bullet_line(ln: str) -> bool:
     s = ln.lstrip()
@@ -122,6 +125,65 @@ def _combine_parts(parts: List[str]) -> str:
     text = re.sub(r"\s{2,}", " ", text)
     return text.strip()
 
+
+def _split_inline_segments(segments: List[str]) -> List[str]:
+    bullets: List[str] = []
+    current: List[str] = []
+
+    def flush() -> None:
+        if not current:
+            return
+        combined = _combine_parts(current)
+        if combined:
+            bullets.append(combined)
+        current.clear()
+
+    for index, segment in enumerate(segments):
+        if not segment:
+            continue
+        if segment == "|":
+            flush()
+            continue
+
+        current.append(segment)
+
+        next_segment = segments[index + 1] if index + 1 < len(segments) else None
+        if not next_segment:
+            continue
+        if next_segment == "|":
+            flush()
+            continue
+        if len(current) >= 2:
+            last = current[-1]
+            if last[:1].isupper() and next_segment[:1].isupper():
+                flush()
+
+    flush()
+    return bullets
+
+
+def _normalize_bullet_text(text: str) -> List[str]:
+    cleaned = text.strip()
+    if not cleaned:
+        return []
+
+    if INLINE_BULLET_PATTERN.search(cleaned):
+        segments = [segment.strip() for segment in INLINE_BULLET_PATTERN.split(cleaned) if segment.strip()]
+        split_segments = _split_inline_segments(segments)
+        if len(split_segments) >= 2:
+            return split_segments
+        if segments:
+            cleaned = " ".join(segments)
+        cleaned = INLINE_BULLET_PATTERN.sub(" ", cleaned)
+
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
+    return [cleaned] if cleaned else []
+
+
+def _append_bullet(target: List[str], text: str) -> None:
+    for bullet in _normalize_bullet_text(text):
+        target.append(bullet)
+
 def split_cv(text: str) -> Dict[str, List[Dict[str, List[str]]]]:
     """
     Heuristic CV splitter for a quick on-screen preview:
@@ -155,7 +217,7 @@ def split_cv(text: str) -> Dict[str, List[Dict[str, List[str]]]]:
                 if parts:
                     combined = _combine_parts(parts)
                     if combined:
-                        current["bullets"].append(combined)
+                        _append_bullet(current["bullets"], combined)
                 parts = [text] if text else []
                 continue
 
@@ -170,7 +232,7 @@ def split_cv(text: str) -> Dict[str, List[Dict[str, List[str]]]]:
         if parts:
             combined = _combine_parts(parts)
             if combined:
-                current["bullets"].append(combined)
+                _append_bullet(current["bullets"], combined)
 
         buffer = []
 
@@ -200,7 +262,7 @@ def split_cv(text: str) -> Dict[str, List[Dict[str, List[str]]]]:
         s = stripped
         if len(s) > 40 or END_PUNCT.search(s):
             flush_buffer_as_bullets()
-            current["bullets"].append(s)
+            _append_bullet(current["bullets"], s)
         else:
             buffer.append(stripped)
 

--- a/jobfit/api/tests/test_parsing.py
+++ b/jobfit/api/tests/test_parsing.py
@@ -37,3 +37,21 @@ def test_split_cv_keeps_distinct_skill_bullets():
     assert preview["sections"]
     skills = preview["sections"][0]
     assert skills["bullets"] == ["Python", "SQL", "AWS"]
+
+
+def test_split_cv_cleans_inline_bullet_markers():
+    text = "\n".join([
+        "Summary",
+        "• Jaron • Seijffers • Product • Executive • | • Data-Driven • Strategy",
+    ])
+
+    preview = split_cv(text)
+
+    assert preview["sections"]
+    summary = preview["sections"][0]
+    assert summary["name"].lower().startswith("summary")
+    assert summary["bullets"] == [
+        "Jaron Seijffers",
+        "Product Executive",
+        "Data-Driven Strategy",
+    ]

--- a/jobfit/api/tests/test_upload.py
+++ b/jobfit/api/tests/test_upload.py
@@ -58,6 +58,19 @@ def test_upload_transcript_text_file():
     assert body["paragraph_counts"][0] > 0
 
 
+def test_upload_context_with_notes_only():
+    response = client.post(
+        "/upload/context",
+        data={"candidate_id": "demo", "notes": "Follow up soon."},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["saved"] is True
+    assert body["sources"]
+    assert body["sources"][0]["filename"] == "notes.txt"
+    assert body["paragraph_counts"] == [1]
+
+
 def test_upload_rejects_invalid_mimetype():
     files = {"cv_file": ("image.png", b"fake", "image/png")}
     response = client.post("/upload/cv", files=files)


### PR DESCRIPTION
## Summary
- normalize inline bullet markers in the CV preview parser so summary text renders cleanly
- make context uploads accept note-only submissions and add coverage for both fixes

## Testing
- pytest tests/test_parsing.py


------
https://chatgpt.com/codex/tasks/task_e_68cd9495cb4883339b50c1feae1a3332